### PR TITLE
update watcher readme

### DIFF
--- a/watcher/README.md
+++ b/watcher/README.md
@@ -14,7 +14,8 @@ database running. The watcher will expect a table named `results` with a
 schema of `CREATE TABLE results (count int)`.
 
 ```
-oc new-app centos/python-36-centos7~https://github.com/elmiko/postgresql-watcher \
+oc new-app centos/python-36-centos7~https://github.com/radanalyticsio/bad-apples \
+  --context-dir=watcher \
   -e DBHOST=postgresql \
   -e DBNAME=finance \
   -e DBUSERNAME=username \


### PR DESCRIPTION
This change fixes the `oc new-app` command to use the new location for
the code base.